### PR TITLE
Add include to fix build failure on Windows.

### DIFF
--- a/src/common/module.cc
+++ b/src/common/module.cc
@@ -42,6 +42,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
Msys recently updated their version of GCC, which caused the Natron windows package build to start failing. This change just adds a missing header to fix the build. This is just a minimal fix to get Natron building again and it is present in Google's upstream repo.